### PR TITLE
Changed README.md to fix problems with showLeaderboard and signout

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ googleplaygame.auth();
 You should provde the option for users to sign out
 
 ```
-googleplaygame.signout();
+googleplaygame.signOut();
 ```
 
 #### Auth status
@@ -98,7 +98,7 @@ Launches directly into the specified leaderboard:
 var data = {
 	leaderboardId: "board1"
 };
-googleplaygame.showLeaderboard(leaderboardId);
+googleplaygame.showLeaderboard(data);
 ```
 
 ### Achievements


### PR DESCRIPTION
There are 2 misprints in the README.md:

1. Sign Out

`googleplaygame.signout();` should be `googleplaygame.signOut();`

2. Show Leaderboards

`var data = { leaderboardId: "board1" }; googleplaygame.showLeaderboard(leaderboardId);`

should be

`var data = { leaderboardId: "board1" }; googleplaygame.showLeaderboard(data);`